### PR TITLE
Adds LAB and HCL color spaces

### DIFF
--- a/src/Color/Lab.elm
+++ b/src/Color/Lab.elm
@@ -1,0 +1,136 @@
+module Color.Lab exposing (from, to)
+
+{-| Implements conversions to and from the CIELAB color space.
+
+For more information about this, see [[[[[[[[[[[[[[[[[[https://en.wikipedia.org/wiki/CIELAB\_color\_space#CIELAB](https://en.wikipedia.org/wiki/CIELAB_color_space#CIELAB)](https://en.wikipedia.org/wiki/CIELAB_color_space#CIELAB)](https://en.wikipedia.org/wiki/CIELAB_color_space#CIELAB)](https://en.wikipedia.org/wiki/CIELAB_color_space#CIELAB)](https://en.wikipedia.org/wiki/CIELAB_color_space#CIELAB)](https://en.wikipedia.org/wiki/CIELAB_color_space#CIELAB)](https://en.wikipedia.org/wiki/CIELAB_color_space#CIELAB)](https://en.wikipedia.org/wiki/CIELAB_color_space#CIELAB)](https://en.wikipedia.org/wiki/CIELAB_color_space#CIELAB)](https://en.wikipedia.org/wiki/CIELAB_color_space#CIELAB)](https://en.wikipedia.org/wiki/CIELAB_color_space#CIELAB)](https://en.wikipedia.org/wiki/CIELAB_color_space#CIELAB)](https://en.wikipedia.org/wiki/CIELAB_color_space#CIELAB)](https://en.wikipedia.org/wiki/CIELAB_color_space#CIELAB)](https://en.wikipedia.org/wiki/CIELAB_color_space#CIELAB)](https://en.wikipedia.org/wiki/CIELAB_color_space#CIELAB)](https://en.wikipedia.org/wiki/CIELAB_color_space#CIELAB)](https://en.wikipedia.org/wiki/CIELAB_color_space#CIELAB).
+
+For an explanation of the math in this module, see <https://observablehq.com/@mbostock/lab-and-rgb>.
+
+-}
+
+-- Constants
+
+
+xn =
+    0.96422
+
+
+zn =
+    0.82521
+
+
+t0 =
+    4 / 29
+
+
+t1 =
+    6 / 29
+
+
+t2 =
+    3 * t1 ^ 2
+
+
+t3 =
+    t1 ^ 3
+
+
+
+-- TO
+
+
+to : Float -> Float -> Float -> { l : Float, a : Float, b : Float }
+to sr sg sb =
+    let
+        ( lr, lg, lb ) =
+            ( srgb2lrgb sr, srgb2lrgb sg, srgb2lrgb sb )
+
+        y =
+            xyz2lab (0.2225045 * lr + 0.7168786 * lg + 0.0606169 * lb)
+
+        ( x, z ) =
+            if lr == lg && lg == lb then
+                ( y, y )
+
+            else
+                ( xyz2lab ((0.4360747 * lr + 0.3850649 * lg + 0.1430804 * lb) / xn), xyz2lab ((0.0139322 * lr + 0.0971045 * lg + 0.7141733 * lb) / zn) )
+    in
+    { l = 116 * y - 16, a = 500 * (x - y), b = 200 * (y - z) }
+
+
+{-| Converts (a coordinate) from the sRGB color space to the linear light RGB, undoing the gamma encoding of sRGB space.
+-}
+srgb2lrgb : Float -> Float
+srgb2lrgb v =
+    if v <= 0.04045 then
+        v / 12.92
+
+    else
+        ((v + 0.055) / 1.055) ^ 2.4
+
+
+{-| Converts (a coordinate) from the XYZ color space to the LAB color space.
+-}
+xyz2lab t =
+    if t > t3 then
+        t ^ (1 / 3)
+
+    else
+        t / t2 + t0
+
+
+
+-- FROM
+
+
+from : Float -> Float -> Float -> { red : Float, green : Float, blue : Float }
+from l a b =
+    let
+        fl =
+            (l + 16) / 116
+
+        fa =
+            if isNaN a then
+                0
+
+            else
+                a / 500
+
+        fb =
+            if isNaN b then
+                0
+
+            else
+                b / 200
+
+        x =
+            xn * lab2xyz (fl + fa)
+
+        y =
+            lab2xyz fl
+
+        z =
+            zn * lab2xyz (fl - fb)
+    in
+    { red = lrgb2srgb (3.1338561 * x - 1.6168667 * y - 0.4906146 * z)
+    , green = lrgb2srgb (-0.9787684 * x + 1.9161415 * y + 0.033454 * z)
+    , blue = lrgb2srgb (0.0719453 * x - 0.2289914 * y + 1.4052427 * z)
+    }
+
+
+{-| Converts (a coordinate) from the LAB color space to the XYZ color space.
+-}
+lab2xyz t =
+    if t > t1 then
+        t ^ 3
+
+    else
+        t2 * (t - t0)
+
+
+lrgb2srgb v =
+    if v <= 0.0031308 then
+        12.92 * v
+
+    else
+        1.055 * (v ^ (1 / 2.4)) - 0.055

--- a/tests/ColorTest.elm
+++ b/tests/ColorTest.elm
@@ -219,27 +219,6 @@ all =
                     |> Color.fromHcl
                     |> Color.toRgba
                     |> expectRgbEqual { red = r, green = g, blue = b, alpha = alpha }
-
-        -- [ \result ->
-        --     if result.lightness == 1 || result.lightness == 0 || result.saturation == 0 then
-        --         -- hue does not apply
-        --         Expect.pass
-        --
-        --     else if h >= 1 then
-        --         result.hue |> Expect.within guaranteedTolerance (h - 1)
-        --
-        --     else
-        --         result.hue |> Expect.within guaranteedTolerance h
-        -- , \result ->
-        --     if result.lightness == 1 || result.lightness == 0 then
-        --         -- saturation does not apply
-        --         Expect.pass
-        --
-        --     else
-        --         result.saturation |> Expect.within guaranteedTolerance s
-        -- , .lightness >> Expect.within guaranteedTolerance l
-        -- , .alpha >> Expect.within guaranteedTolerance a
-        -- ]
         , fuzz (tuple2 (tuple3 unit unit unit) unit)
             "can represent HSLA colors (hsla)"
           <|


### PR DESCRIPTION
This PR adds the math to specify and output colors in the CIELAB and HCL color spaces. 

These are especially useful for information visualization as they are perceptually uniform, but are also suitable for color manipulation and UI tasks, like generating palettes or themes.

There are some open API design questions/caveats:

-  [ ] I didn't include convenience constructors. Seems like these are somewhat less common, so having just the record based thing seemed fine. But it is somewhat inconsistent with the others.
- [ ] The coordinates are not normalized like the others. I've not seen them used normalized anywhere, so would consider that strange (also the ranges are not limited like RGB, but are more "recommended", so normalization is somewhat subjective).
- [ ] As there is a lot more computation, there is considerably more rounding error. I think this is fine.
- [ ] Lab's channels don't really have human names. They are called `L*`, `a*` and `b*`. This makes the record a bit awkward...
- [ ] Hcl in the reference implementation I was following explicitly uses `NaN` values for hue and chroma for black, white, and `NaN` chroma for  grays.

I would be grateful for direction on the above points.